### PR TITLE
send not works on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function send(ctx, path, opts) {
 
   // options
   debug('send "%s" %j', path, opts);
-  var root = opts.root ? resolve(opts.root) : '';
+  var root = opts.root ? normalize(resolve(opts.root)) : '';
   var index = opts.index;
   var maxage = opts.maxage || 0;
   var hidden = opts.hidden || false;


### PR DESCRIPTION
koa-send throws "malicious path" error on Windows.

Because `path.normalize` converts a drive name to lower case (ex. `C:\hello.txt` -> `c:hello.txt` ).
`root` is not normalized, and `path` is normalized.
So `0 != path.indexOf(root)` at line 68 become to `false`

Sorry my English is poor.
