### PR TITLE
Directories without a trailing slash #27

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,6 +22,7 @@ $ npm install koa-send
  - `hidden` Allow transfer of hidden files. defaults to false
  - `root` Root directory to restrict file access
  - `gzip` Try to serve the gzipped version of a file automatically when `gzip` is supported by a client and if the requested file with `.gz` extension exists. defaults to true.
+ - `format` If true, format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/`
 
 ## Root path
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,17 @@ function send(ctx, path, opts) {
     // stat
     try {
       var stats = yield fs.stat(path);
-      if (stats.isDirectory()) return;
+
+      // Format the path to serve static file servers
+      // and not require a trailing slash for directories,
+      // so that you can do both `/directory` and `/directory/`
+      if (stats.isDirectory()) {
+        if (opts.format) {
+          path += '/' + index;
+        } else {
+          return;
+        }
+      }
     } catch (err) {
       var notfound = ['ENOENT', 'ENAMETOOLONG', 'ENOTDIR'];
       if (~notfound.indexOf(err.code)) return;

--- a/test/index.js
+++ b/test/index.js
@@ -187,6 +187,49 @@ describe('send(ctx, file)', function(){
     })
   })
 
+  describe('when path does not finish with slash and format is disabled', function(){
+    it('should 200', function(done){
+      var app = koa();
+
+      app.use(function *(){
+        var opts = { root: 'test', index: 'index.html' };
+        yield send(this, 'fixtures/world', opts);
+      });
+
+      request(app.listen())
+        .get('/world')
+        .expect(404, done);
+    })
+
+    it('should 200', function(done){
+      var app = koa();
+
+      app.use(function *(){
+        var opts = { root: 'test', index: 'index.html', format: false };
+        yield send(this, 'fixtures/world', opts);
+      });
+
+      request(app.listen())
+        .get('/world')
+        .expect(404, done);
+    })
+  })
+
+  describe('when path does not finish with slash and format is enabled', function(){
+    it('should 200', function(done){
+      var app = koa();
+
+      app.use(function *(){
+        var opts = { root: 'test', index: 'index.html', format: true };
+        yield send(this, 'fixtures/world', opts);
+      });
+
+      request(app.listen())
+        .get('/')
+        .expect(200, done);
+    })
+  })
+
   describe('when path is malformed', function(){
     it('should 400', function(done){
       var app = koa();

--- a/test/index.js
+++ b/test/index.js
@@ -188,7 +188,7 @@ describe('send(ctx, file)', function(){
   })
 
   describe('when path does not finish with slash and format is disabled', function(){
-    it('should 200', function(done){
+    it('should 404', function(done){
       var app = koa();
 
       app.use(function *(){
@@ -201,7 +201,7 @@ describe('send(ctx, file)', function(){
         .expect(404, done);
     })
 
-    it('should 200', function(done){
+    it('should 404', function(done){
       var app = koa();
 
       app.use(function *(){


### PR DESCRIPTION
Format the path to serve static file servers and not require a trailing slash for directories, so that you can do both /directory and /directory/.