### PR TITLE
Fixes #34

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ function send(ctx, path, opts) {
       if (stats.isDirectory()) {
         if (format && index) {
           path += '/' + index;
+          stats = yield fs.stat(path);
         } else {
           return;
         }


### PR DESCRIPTION
fs.stat() needs to be called again after changing the path because it contains info about the _directory_ rather than the _index file_. Tests pass on Linux.