### PR TITLE
Updating examples to remove invalid use of absolute paths.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,7 +60,7 @@ var app = new Koa();
 
 app.use(async function (ctx, next){
   if ('/' == ctx.path) return ctx.body = 'Try GET /package.json';
-  await send(ctx, __dirname + '/package.json');
+  await send(ctx, 'package.json');
 })
 
 app.listen(3000);
@@ -79,7 +79,7 @@ var app = koa();
 
 app.use(function *(){
   if ('/' == this.path) return this.body = 'Try GET /package.json';
-  yield send(this, __dirname + '/package.json');
+  yield send(this, 'package.json');
 })
 
 app.listen(3000);


### PR DESCRIPTION
Absolute paths are no longer supported. This has been annotated in the documentation, but these two examples were still using them.