### PR TITLE
Make content length available in context.

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ function send(ctx, path, opts) {
     ctx.set('Cache-Control', 'max-age=' + (maxage / 1000 | 0));
     ctx.type = type(path);
     ctx.body = fs.createReadStream(path);
+    ctx.length = stats.size;
 
     return path;
   });


### PR DESCRIPTION
For example, when implementing Content-Range headers it is useful to have access to the file size.
It is already set in the header but it is nice to be able to access it directly in the context.
