### PR TITLE
Add info about `index` option to the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,12 +19,13 @@ $ npm install koa-send
 ## Options
 
  - `maxage` Browser cache max-age in milliseconds. (defaults to `0`)
- - `immutable` Tell the browser the resource is immutable and can be cached indefinitely (defaults to `false`)
+ - `immutable` Tell the browser the resource is immutable and can be cached indefinitely. (defaults to `false`)
  - `hidden` Allow transfer of hidden files. (defaults to `false`)
- - [`root`](#root-path) Root directory to restrict file access
- - `gzip` Try to serve the gzipped version of a file automatically when `gzip` is supported by a client and if the requested file with `.gz` extension exists. defaults to true.
- - `brotli` Try to serve the brotli version of a file automatically when `brotli` is supported by a client and if the requested file with `.br` extension exists. defaults to true.
- - `format` If not `false` (defaults to `true`), format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/`
+ - [`root`](#root-path) Root directory to restrict file access.
+ - `index` Name of the index file to serve automatically when visiting the root location. (defaults to none)
+ - `gzip` Try to serve the gzipped version of a file automatically when `gzip` is supported by a client and if the requested file with `.gz` extension exists. (defaults to `true`).
+ - `brotli` Try to serve the brotli version of a file automatically when `brotli` is supported by a client and if the requested file with `.br` extension exists. (defaults to `true`).
+ - `format` If not `false` (defaults to `true`), format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/`.
  - [`setHeaders`](#setheaders) Function to set custom headers on response.
  - `extensions` Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
 


### PR DESCRIPTION
It's documented in the tests, but it's missing from readme.
Added some minor formatting changes also.