### PR TITLE
Adds secondary "legacy" Node v6 Support via Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    ["@babel/preset-env", {
+      "targets": {
+        "node": "6.11"
+      }
+    }]
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 node_modules
 coverage
+legacy/*.js

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "index.js"
   ],
   "devDependencies": {
+    "@babel/cli": "^7.0.0-beta.39",
+    "@babel/core": "^7.0.0-beta.39",
+    "@babel/polyfill": "^7.0.0-beta.39",
+    "@babel/preset-env": "^7.0.0-beta.39",
+    "@babel/register": "^7.0.0-beta.39",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.2.0",
@@ -35,6 +40,7 @@
   },
   "scripts": {
     "lint": "eslint --fix .",
+    "prepublishOnly": "babel index.js --out-file legacy/index.js",
     "test": "mocha --require should --reporter spec",
     "test-cov": "istanbul cover ./node_modules/.bin/_mocha -- --require should",
     "test-travis": "istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- --require should"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "sendfile"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "legacy/index.js"
   ],
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.39",


### PR DESCRIPTION
In follow-up to [koajs/static #123](https://github.com/koajs/static/issues/123) and due to a blocking issue with `@babel/register` in [webpack-serve](/webpack-contrib/webpack-serve), I put this PR together. Apologies for not waiting on an answer, but the blocking issue with Babel was holding a beta release of that module up, and the only clear solution was to roll out user-scoped versions of `koa-static` and `koa-send` that allow Node v6 support. 

This PR changes a few things:

- adds a `.babelrc` file with the correct configuration to produce output for Node v6.
- adds `prepublishOnly` script to automatically create the `legacy/index.js` file for publish.

So as not to imply direct support of Node v6 I did not change the `engines` property in package.json. This PR (and a publish of the module) is required for https://github.com/koajs/static/pull/124 to work properly.

For anyone needing this support immediately, you can use my user-scoped module here: https://www.npmjs.com/package/@shellscape/koa-send