### PR TITLE
Fix errors with index handling; permit multiple indexes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,85 +61,109 @@ async function send (ctx, path, opts = {}) {
   path = decode(path)
 
   if (path === -1) return ctx.throw(400, 'failed to decode')
-
-  // index file support
-  if (index && trailingSlash) path += index
-
   path = resolvePath(root, path)
 
-  // hidden file support, ignore
-  if (!hidden && isHidden(root, path)) return
+  /**
+   * Create a list of all possible matches for the given path and options
+   * The list will be in order of preferred match, namely, for each possible index:
+   * A brotli version of the index
+   * A gzip version of the index
+   * The index
+   * A brotli version of the index with one of its extensions
+   * A gip version of the index with one of its extensions
+   * The index with one of its extension
+   */
+  let paths = [].concat(trailingSlash ? index : [].concat('', index)) // All of the possible index files
+  .map(i=>path + (i ? '/' : '') + i) // The permutations of the path with all of the possible indexes
+  .reduce((p,c)=>{ // each c is a possible match. Collect the compressed and extended versions and the compressed versions of the extended versions
+    let eP = extendedPath(c)
+    return p.concat(
+      compressedPath(ctx, c, brotli, gzip)
+      ,{path:c, ext: extname(c)}
+      ,eP.reduce((o,n)=>o.concat(compressedPath(ctx, n, brotli, gzip), n), []) 
+    )
+  }, [])
 
-  let encodingExt = ''
-  // serve brotli file when possible otherwise gzipped file when possible
-  if (ctx.acceptsEncodings('br', 'identity') === 'br' && brotli && (await fs.exists(path + '.br'))) {
-    path = path + '.br'
-    ctx.set('Content-Encoding', 'br')
-    ctx.res.removeHeader('Content-Length')
-    encodingExt = '.br'
-  } else if (ctx.acceptsEncodings('gzip', 'identity') === 'gzip' && gzip && (await fs.exists(path + '.gz'))) {
-    path = path + '.gz'
-    ctx.set('Content-Encoding', 'gzip')
-    ctx.res.removeHeader('Content-Length')
-    encodingExt = '.gz'
+  for (path of paths) {
+    // hidden file support, ignore
+    if (!hidden && isHidden(root, path.path)) continue
+
+    // stat
+    let stats
+    try {
+      stats = await fs.stat(path)
+      if (stats.isDirectory()) continue
+    } catch (err) {
+      const notfound = ['ENOENT', 'ENAMETOOLONG', 'ENOTDIR']
+      if (notfound.includes(err.code)) {
+        continue
+      }
+      err.status = 500
+      throw err
+    }
+
+    /**
+     * The current path permutation exists and is not a directory
+     * We will serve this and be done
+     */
+    if (setHeaders) setHeaders(ctx.res, path, stats)
+
+    // stream
+    ctx.set('Content-Length', stats.size)
+    if (!ctx.response.get('Last-Modified')) ctx.set('Last-Modified', stats.mtime.toUTCString())
+    if (!ctx.response.get('Cache-Control')) {
+      const directives = ['max-age=' + (maxage / 1000 | 0)]
+      if (immutable) {
+        directives.push('immutable')
+      }
+      ctx.set('Cache-Control', directives.join(','))
+    }
+    ctx.type = path.ext
+    if (path.fixup) path.fixup()
+    ctx.body = fs.createReadStream(path.path)
+    return path.path
   }
+  throw createError(404)
+}
 
-  if (extensions && !/\.[^/]*$/.exec(path)) {
+/**
+ * Return permutations of the path appended with compression option extensions
+ */
+
+function compressedPath(ctx, path, brotli, gzip){
+  let paths = []
+  // serve brotli file when possible otherwise gzipped file when possible
+  if (brotli && 'br' === ctx.acceptsEncodings('br', 'identity') && ! /\.br$/.test(path)){
+    paths.push({path: path + '.br', ext: extname(path), fixup: function(){
+      ctx.set('Content-Encoding', 'br')
+      ctx.res.removeHeader('Content-Length')
+    }})
+  }
+  if (gzip && 'gzip' === ctx.acceptsEncodings('gzip', 'identity') && ! /\.gz$/.test(path)){
+    paths.push({path: path + '.gz', ext: extname(path), fixup: function(){
+      ctx.set('Content-Encoding', 'gzip')
+      ctx.res.removeHeader('Content-Length')
+    }})
+  }
+  return paths
+}
+
+/**
+ * Return permutations of the path appended with option extensions
+ */
+
+function extendedPath(path, extensions){
+  let paths = []
+  if (extensions && !/\.[^/]*$/.test(path)) {
     const list = [].concat(extensions)
-    for (let i = 0; i < list.length; i++) {
-      let ext = list[i]
-      if (typeof ext !== 'string') {
+    for (ext of list){
+      if ('string' !== typeof ext) {
         throw new TypeError('option extensions must be array of strings or false')
       }
-      if (!/^\./.exec(ext)) ext = '.' + ext
-      if (await fs.exists(path + ext)) {
-        path = path + ext
-        break
-      }
+      ext.replace(/^\./, '')
+      paths.push({path: [path,ext].join('.'), ext})
     }
   }
-
-  // stat
-  let stats
-  try {
-    stats = await fs.stat(path)
-
-    // Format the path to serve static file servers
-    // and not require a trailing slash for directories,
-    // so that you can do both `/directory` and `/directory/`
-    if (stats.isDirectory()) {
-      if (format && index) {
-        path += '/' + index
-        stats = await fs.stat(path)
-      } else {
-        return
-      }
-    }
-  } catch (err) {
-    const notfound = ['ENOENT', 'ENAMETOOLONG', 'ENOTDIR']
-    if (notfound.includes(err.code)) {
-      throw createError(404, err)
-    }
-    err.status = 500
-    throw err
-  }
-
-  if (setHeaders) setHeaders(ctx.res, path, stats)
-
-  // stream
-  ctx.set('Content-Length', stats.size)
-  if (!ctx.response.get('Last-Modified')) ctx.set('Last-Modified', stats.mtime.toUTCString())
-  if (!ctx.response.get('Cache-Control')) {
-    const directives = ['max-age=' + (maxage / 1000 | 0)]
-    if (immutable) {
-      directives.push('immutable')
-    }
-    ctx.set('Cache-Control', directives.join(','))
-  }
-  ctx.type = type(path, encodingExt)
-  ctx.body = fs.createReadStream(path)
-
-  return path
 }
 
 /**
@@ -152,14 +176,6 @@ function isHidden (root, path) {
     if (path[i][0] === '.') return true
   }
   return false
-}
-
-/**
- * File type.
- */
-
-function type (file, ext) {
-  return ext !== '' ? extname(basename(file, ext)) : extname(file)
 }
 
 /**


### PR DESCRIPTION
This allows options.index to be an array of indexes, prioritized by list order.

It also removes a pretty obscure error whereby

````js
send(ctx, 'path/to/', {index: 'index', extensions:['html','htm']})
````

could serve `path/to/index.html/index`