### PR TITLE
add range support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,7 @@ $ npm install koa-send
  - `format` If not `false` (defaults to `true`), format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/`.
  - [`setHeaders`](#setheaders) Function to set custom headers on response.
  - `extensions` Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
+ - `range` Allow range request of partial content. (defaults to `false`)
 
 ### Root path
 

--- a/example.js
+++ b/example.js
@@ -11,7 +11,7 @@ app.use(async (ctx) => {
     ctx.body = 'Try GET /package.json'
     return
   }
-  await send(ctx, ctx.path, { root: __dirname })
+  await send(ctx, ctx.path, { root: __dirname, range: true })
 })
 
 app.listen(3000)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "byte-range-stream": "^2.0.1",
     "debug": "^3.1.0",
     "http-errors": "^1.6.3",
     "mz": "^2.7.0",


### PR DESCRIPTION
here is some test:
`curl http://localhost:3000/package.json -i -H "Range: bytes=0-50, 100-150"` 
 
```
HTTP/1.1 200 OK
Accept-Ranges: bytes
Last-Modified: Wed, 27 Mar 2019 11:20:08 GMT
Cache-Control: max-age=0
Content-Type: multipart/byteranges; boundary=--------------------------674091310343117359970110
Content-Length: 375
Date: Wed, 27 Mar 2019 11:45:17 GMT
Connection: keep-alive

--------------------------674091310343117359970110
Content-Type: .json
Content-Range: bytes 0-50/1149

{
  "name": "koa-send",
  "description": "Transfer
--------------------------674091310343117359970110
Content-Type: .json
Content-Range: bytes 100-150/1149

ersion": "5.0.0",
  "keywords": [
    "koa",
    "f
--------------------------674091310343117359970110--
```