### PR TITLE
option "setHeaders" args[0] change to the Koa response object

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,7 @@ app.use(async (ctx) => {
 ### setHeaders
 
 The function is called as `fn(res, path, stats)`, where the arguments are:
-* `res`: the response object
+* `res`: the Koa response object
 * `path`: the resolved file path that is being sent
 * `stats`: the stats object of the file that is being sent.
 

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ async function send (ctx, path, opts = {}) {
     throw err
   }
 
-  if (setHeaders) setHeaders(ctx.res, path, stats)
+  if (setHeaders) setHeaders(ctx.response, path, stats)
 
   // stream
   ctx.set('Content-Length', stats.size)


### PR DESCRIPTION
I think most people are used to using " Koa Response" in koa or not "Node Response"。
Just like use ctx.response.set('Cache-Control', 'max-age=0') or not ctx.res.setHeader(...)。
Because Koa officially states [Bypassing Koa's response handling is not supported](https://github.com/koajs/koa/blob/master/docs/api/context.md#ctxres)