### PR TITLE
Extend `format` option support redirection of trailing slash for directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install koa-send
  - `index` Name of the index file to serve automatically when visiting the root location. (defaults to none).
  - `gzip` Try to serve the gzipped version of a file automatically when `gzip` is supported by a client and if the requested file with `.gz` extension exists. (defaults to `true`).
  - `brotli` Try to serve the brotli version of a file automatically when `brotli` is supported by a client and if the requested file with `.br` extension exists. (defaults to `true`).
- - `format` If not `false` (defaults to `follow`), format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/` transparently. If it is `redirect`, issue a HTTP 302 redirection to the url with trailing slash.
+ - `format` If not `false` (defaults to `'follow'`), format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/` transparently. If it is `'redirect'`, issue a HTTP 302 redirection to the url with trailing slash.
  - [`setHeaders`](#setheaders) Function to set custom headers on response.
  - `extensions` Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install koa-send
  - `index` Name of the index file to serve automatically when visiting the root location. (defaults to none).
  - `gzip` Try to serve the gzipped version of a file automatically when `gzip` is supported by a client and if the requested file with `.gz` extension exists. (defaults to `true`).
  - `brotli` Try to serve the brotli version of a file automatically when `brotli` is supported by a client and if the requested file with `.br` extension exists. (defaults to `true`).
- - `format` If not `false` (defaults to `true`), format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/`.
+ - `format` If not `false` (defaults to `follow`), format the path to serve static file servers and not require a trailing slash for directories, so that you can do both `/directory` and `/directory/` transparently. If it is `redirect`, issue a HTTP 302 redirection to the url with trailing slash.
  - [`setHeaders`](#setheaders) Function to set custom headers on response.
  - `extensions` Try to match extensions from passed array to search for file when no extension is sufficed in URL. First found is served. (defaults to `false`)
 

--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ async function send (ctx, path, opts = {}) {
         stats = await fs.stat(path)
       } else if (format === 'redirect' && index) {
         ctx.redirect(ctx.request.origin + ctx.request.path + '/' + ctx.request.search)
-        return
+        return true
       } else {
         return
       }


### PR DESCRIPTION
Extended `format` option from `( *true | false )` to `( *'follow' | 'redirect' | false )`.

`'follow'` behaves the same as the old `true`, and keep as default.
`'redirect'` is used for the redirection new feature.

If trailing slash for directories is absent and index is defined, when `format` is set to `'redirect'`, it redirects the page using HTTP 302 to the URL with trailing slash added, at the same time respecting previous scheme and query.

Return value of `await send()` is `true` when such a redirection happened, in contrast of `undefined` when encountering errors and `pathname` when the file is served.