### PR TITLE
Replace mz with custom promisified wrappers

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,24 @@
  * Module dependencies.
  */
 
+const fs = require('fs')
+const util = require('util')
 const debug = require('debug')('koa-send')
 const resolvePath = require('resolve-path')
 const createError = require('http-errors')
 const assert = require('assert')
-const fs = require('mz/fs')
+
+const stat = util.promisify(fs.stat)
+const access = util.promisify(fs.access)
+
+async function exists (path) {
+  try {
+    await access(path)
+    return true
+  } catch (e) {
+    return false
+  }
+}
 
 const {
   normalize,
@@ -72,12 +85,12 @@ async function send (ctx, path, opts = {}) {
 
   let encodingExt = ''
   // serve brotli file when possible otherwise gzipped file when possible
-  if (ctx.acceptsEncodings('br', 'identity') === 'br' && brotli && (await fs.exists(path + '.br'))) {
+  if (ctx.acceptsEncodings('br', 'identity') === 'br' && brotli && (await exists(path + '.br'))) {
     path = path + '.br'
     ctx.set('Content-Encoding', 'br')
     ctx.res.removeHeader('Content-Length')
     encodingExt = '.br'
-  } else if (ctx.acceptsEncodings('gzip', 'identity') === 'gzip' && gzip && (await fs.exists(path + '.gz'))) {
+  } else if (ctx.acceptsEncodings('gzip', 'identity') === 'gzip' && gzip && (await exists(path + '.gz'))) {
     path = path + '.gz'
     ctx.set('Content-Encoding', 'gzip')
     ctx.res.removeHeader('Content-Length')
@@ -92,7 +105,7 @@ async function send (ctx, path, opts = {}) {
         throw new TypeError('option extensions must be array of strings or false')
       }
       if (!/^\./.exec(ext)) ext = `.${ext}`
-      if (await fs.exists(`${path}${ext}`)) {
+      if (await exists(`${path}${ext}`)) {
         path = `${path}${ext}`
         break
       }
@@ -102,7 +115,7 @@ async function send (ctx, path, opts = {}) {
   // stat
   let stats
   try {
-    stats = await fs.stat(path)
+    stats = await stat(path)
 
     // Format the path to serve static file servers
     // and not require a trailing slash for directories,
@@ -110,7 +123,7 @@ async function send (ctx, path, opts = {}) {
     if (stats.isDirectory()) {
       if (format && index) {
         path += `/${index}`
-        stats = await fs.stat(path)
+        stats = await stat(path)
       } else {
         return
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "debug": "^4.1.1",
     "http-errors": "^1.7.3",
-    "mz": "^2.7.0",
     "resolve-path": "^1.4.0"
   },
   "scripts": {


### PR DESCRIPTION
util.promisify is supported since node v8
https://nodejs.org/api/util.html#util_util_promisify_original

fs.access is supported since 0.11 and recommended for checking file
existence.
https://nodejs.org/api/fs.html#fs_fs_access_path_mode_callback

Btw node v10 has `const { promises: fs } = require('fs')` support