### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ async function send (ctx, path, opts = {}) {
   debug('send "%s" %j', path, opts)
   const root = opts.root ? normalize(resolve(opts.root)) : ''
   const trailingSlash = path[path.length - 1] === '/'
-  path = path.substr(parse(path).root.length)
+  path = path.slice(parse(path).root.length)
   const index = opts.index
   const maxage = opts.maxage || opts.maxAge || 0
   const immutable = opts.immutable || false
@@ -160,7 +160,7 @@ async function send (ctx, path, opts = {}) {
  */
 
 function isHidden (root, path) {
-  path = path.substr(root.length).split(sep)
+  path = path.slice(root.length).split(sep)
   for (let i = 0; i < path.length; i++) {
     if (path[i][0] === '.') return true
   }

--- a/test/index.js
+++ b/test/index.js
@@ -779,7 +779,7 @@ describe('send(ctx, file)', function () {
       app.use(async (ctx) => {
         await send(ctx, testFilePath, {
           setHeaders: function (res, path, stats) {
-            assert.equal(path.substr(-normalizedTestFilePath.length), normalizedTestFilePath)
+            assert.equal(path.slice(-normalizedTestFilePath.length), normalizedTestFilePath)
             assert.equal(stats.size, 18)
             assert(res)
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.