### PR TITLE
feat: display which path failed to decode

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -293,6 +293,19 @@ describe('send(ctx, file)', function () {
         .get('/')
         .expect(400, done)
     })
+
+    it('should display which path causes decode error', function (done) {
+      const app = new Koa()
+      const path = '%public_folder%/favicon.ico'
+
+      app.use(async (ctx) => {
+        await send(ctx, '/' + path)
+      })
+
+      request(app.listen())
+        .get('/')
+        .expect('failed to decode ' + path, done)
+    })
   })
 
   describe('when path is a file', function () {


### PR DESCRIPTION
## Why

Hello, when I started a koa server and sent a template HTML to the client, the server showed an error "failed to decode BadRequestError: failed to decode" which is not clear enough to let me spot the issue instantly.

After more investigation, I found it's caused by the URL specified in the HTML template being malformed to the koa server. 

So I think it might help to let the developer know the root cause immediately by enhancing the error message to display the path that failed to decode.

## Screenshots

<img width="1647" alt="image" src="https://user-images.githubusercontent.com/3367820/180418588-617b888c-fc40-4a4a-a1fb-e6098e9f6f7d.png">

<img width="1320" alt="image" src="https://user-images.githubusercontent.com/3367820/180418901-dda57e5a-0004-4312-b76b-5ce65486a7ef.png">

## Thanks for your time to review!

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
